### PR TITLE
Use RotatingFileHandler to prevent unbounded log file growth

### DIFF
--- a/src/util/log_setup.py
+++ b/src/util/log_setup.py
@@ -143,11 +143,13 @@ def setup_logging(manager):
                 "stream": "ext://sys.stdout",
             },
             "file": {
-                "class": "logging.FileHandler",
+                "class": "logging.handlers.RotatingFileHandler",
                 "encoding": "utf-8",
                 "filename": log_path,
                 "level": "DEBUG" if manager.get_debug() else "INFO",
                 "formatter": "millisecondFormatter",
+                "maxBytes": 5 * 1024 * 1024,  # 5 MB
+                "backupCount": 3,
             },
         },
         "loggers": {


### PR DESCRIPTION
## Summary

The current `FileHandler` allows log files to grow indefinitely, which can consume significant disk space. I observed 150+ GB of log files after extended use.

This change switches to `RotatingFileHandler` with:
- **5 MB** max file size
- **3 backup files** retained

This limits total log storage to ~20 MB per session while preserving recent logs for debugging.

## Changes

- `src/util/log_setup.py`: Replace `logging.FileHandler` with `logging.handlers.RotatingFileHandler`

## Test plan

- [x] Verified logs rotate correctly when exceeding 5 MB
- [x] Confirmed backup files (.log.1, .log.2, .log.3) are created
- [x] Existing `delete_old_logs()` regex already handles rotated file naming